### PR TITLE
Fixed typo in rc.local

### DIFF
--- a/foxbuntu/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-ubuntu/etc/rc.local
+++ b/foxbuntu/project/cfg/BoardConfig_IPC/overlay/overlay-luckfox-ubuntu/etc/rc.local
@@ -7,7 +7,7 @@ luckfox-config load
 
 #run only on first boot
 if [ -e "/usr/local/bin/.firstboot" ]; then
-  /usr/local/bin/femto_runonce.sh
+  /usr/local/bin/femto-runonce.sh
 fi
 
 # try enable RTC


### PR DESCRIPTION
  /usr/local/bin/femto_runonce.sh should be
  /usr/local/bin/femto-runonce.sh