### PR TITLE
Update Avahi meshtasticd.service

### DIFF
--- a/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/avahi/services/meshtasticd.service
+++ b/foxbuntu/sysdrv/out/rootfs_uclibc_rv1106/etc/avahi/services/meshtasticd.service
@@ -3,7 +3,7 @@
 <service-group>
   <name>Meshtastic</name>
   <service protocol="ipv4">
-    <type>_http._tcp</type>
-    <port>80</port>
+    <type>_meshtastic._tcp</type>
+    <port>4403</port>
   </service>
 </service-group>


### PR DESCRIPTION
The current config works but I believe it's proper to use _meshtastic._tcp on port 4403.

This has recently changed in the docs:
https://github.com/meshtastic/meshtastic/pull/1666